### PR TITLE
Fix registration with blank password

### DIFF
--- a/express_server.js
+++ b/express_server.js
@@ -142,7 +142,7 @@ app.post("/register", (req, res) => {
   const email = req.body.email;
   const password = req.body.password;
   
-  if (email) {
+  if (email && password) {
     const { userDB, error } = findUserByEmail(email, users);
     if (userDB) {
       res.render("urls_error", { userDB: null, error: `User ${email} already registered` });
@@ -154,7 +154,7 @@ app.post("/register", (req, res) => {
       res.render("urls_index", templateVars);
     }
   } else {
-    res.render("urls_error", { userDB: null, error: "You need to inform your email for registration"} );
+    res.render("urls_error", { userDB: null, error: "You need to inform your email and passwordfor registration"} );
   }
 });
 


### PR DESCRIPTION
After refactoring the function to check if an email and or password has been provided during the registration I forgot to implement the exception back. This was causing the bug of allowing users to register without a password.

Even with the system allowing users to add new accounts without a password, it is not possible to login using the email address only.

This PR closes #11 